### PR TITLE
refactor: error tracking counters

### DIFF
--- a/cp-agent/cp_agent/agents/coder/state_manager.py
+++ b/cp-agent/cp_agent/agents/coder/state_manager.py
@@ -55,7 +55,8 @@ class ToolState:
         self.completed_tools: Set[str] = set()
         self.failed_tools: Set[str] = set()
         self.tool_results: list[Dict[str, Any]] = []
-        self.consecutive_mistakes: int = 0
+        self.consecutive_tool_failures: int = 0
+        self.consecutive_code_failures: int = 0
 
     def add_success(
         self,
@@ -67,7 +68,7 @@ class ToolState:
     ) -> None:
         """Record a successful tool execution."""
         self.completed_tools.add(tool_name)
-        self.consecutive_mistakes = 0
+        self.consecutive_tool_failures = 0
 
         self.tool_results.append(
             {
@@ -90,7 +91,7 @@ class ToolState:
     ) -> None:
         """Record a failed tool execution."""
         self.failed_tools.add(tool_name)
-        self.consecutive_mistakes += 1
+        self.consecutive_tool_failures += 1
 
         self.tool_results.append(
             {
@@ -124,7 +125,8 @@ class StateManager:
         self.tool.completed_tools.clear()
         self.tool.failed_tools.clear()
         self.tool.tool_results.clear()
-        self.tool.consecutive_mistakes = 0
+        self.tool.consecutive_tool_failures = 0
+        self.tool.consecutive_code_failures = 0
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert the current state to a dictionary."""
@@ -136,5 +138,6 @@ class StateManager:
             "completed_tools": list(self.tool.completed_tools),
             "failed_tools": list(self.tool.failed_tools),
             "tool_results": self.tool.tool_results,
-            "consecutive_mistakes": self.tool.consecutive_mistakes,
+            "consecutive_tool_failures": self.tool.consecutive_tool_failures,
+            "consecutive_code_failures": self.tool.consecutive_code_failures,
         }


### PR DESCRIPTION
This pull request focuses on refining the error handling and tracking mechanisms for code execution and tool usage within the `cp-agent` project. The primary changes include renaming and splitting the `consecutive_mistakes` counter into two separate counters: `consecutive_tool_failures` and `consecutive_code_failures`, and updating the relevant methods and conditions to use these new counters.

Key changes include:

### Error Handling and Tracking Improvements:
* Renamed `consecutive_mistakes` to `consecutive_code_failures` and added logging for consecutive code failures in `_on_code_check_complete` method.
* Updated the `_recursively_process_messages` method to check for both `consecutive_tool_failures` and `consecutive_code_failures` and reset both counters after getting feedback. [[1]](diffhunk://#diff-d3c8a8af98f8d1d9f27f8de719531f7518baa8da61d610c57344b7d04ca8c1f0L291-R300) [[2]](diffhunk://#diff-d3c8a8af98f8d1d9f27f8de719531f7518baa8da61d610c57344b7d04ca8c1f0L306-R317)
* Renamed `consecutive_mistakes` to `consecutive_tool_failures` and added `consecutive_code_failures` in the `StateManager` class initialization.

### Method Updates:
* Updated the `add_success` and `add_failure` methods to reset or increment the `consecutive_tool_failures` counter. [[1]](diffhunk://#diff-a00f3b54485744ca56ece23fb7231b9bece8eb6fb77db3d8a19c5212c627e66eL70-R71) [[2]](diffhunk://#diff-a00f3b54485744ca56ece23fb7231b9bece8eb6fb77db3d8a19c5212c627e66eL93-R94)
* Reset both `consecutive_tool_failures` and `consecutive_code_failures` in the `reset_for_new_task` method.

### State Representation:
* Updated the `to_dict` method to include both `consecutive_tool_failures` and `consecutive_code_failures` in the state dictionary.