### PR TITLE
fix: ensure tool param keys snake cased

### DIFF
--- a/cp-agent/cp_agent/agents/coder/tool_executor.py
+++ b/cp-agent/cp_agent/agents/coder/tool_executor.py
@@ -166,8 +166,11 @@ class ToolExecutor:
                     f"Tool '{tool_name}' not found",
                 )
 
+            # Convert kebab-case keys to snake_case keys
+            snake_case_params = {k.replace("-", "_"): v for k, v in params.items()}
+
             tool = self._tools[tool_name]
-            return await tool.execute(**params)
+            return await tool.execute(**snake_case_params)
 
         except ToolError:
             # Re-raise ToolError directly


### PR DESCRIPTION
This pull request includes a change to the `execute_tool` method in the `cp-agent/cp_agent/agents/coder/tool_executor.py` file. The change converts kebab-case keys in the `params` dictionary to snake_case keys before executing the tool.

* [`cp-agent/cp_agent/agents/coder/tool_executor.py`](diffhunk://#diff-cad91b13539f4ff85403412dbc627ca047126f72023a9d79e43ddfe6ffd392b1R169-R173): Added a conversion from kebab-case to snake_case for keys in the `params` dictionary before executing the tool.