### PR TITLE
fix: convert commit date string to iso8601

### DIFF
--- a/cp-webapp/src/components/snapshot-view/commits-list.tsx
+++ b/cp-webapp/src/components/snapshot-view/commits-list.tsx
@@ -22,6 +22,7 @@ import { Commit } from '@/generated/runner/types.gen';
 import { GitCommit } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import { useSnapshotContext } from './context';
+import { convertToISO8601 } from '@/lib/utils';
 
 interface CommitsListProps {
   commits: Commit[];
@@ -156,7 +157,7 @@ export const CommitsList: React.FC<CommitsListProps> = ({
                         </div>
                         <div className="line-clamp-2 break-words text-sm">{commit.message}</div>
                         <div className="text-xs text-gray-500 dark:text-gray-400">
-                          {new Date(commit.date).toLocaleString(undefined, {
+                          {new Date(convertToISO8601(commit.date)).toLocaleString(undefined, {
                             year: 'numeric',
                             month: 'numeric',
                             day: 'numeric',

--- a/cp-webapp/src/lib/utils.ts
+++ b/cp-webapp/src/lib/utils.ts
@@ -21,3 +21,21 @@ export function getProxiedImageUrl(url: string) {
   // Using Cloudflare's proxy service
   return `https://images.1choice.ai?url=${encodeURIComponent(url)}`;
 }
+
+export function convertToISO8601(dateString: string): string {
+  // Check if the input string matches the expected format
+  const regex = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}) ([+-]\d{4})$/;
+  const match = dateString.match(regex);
+
+  if (!match) {
+    throw new Error('Invalid date format. Expected format: YYYY-MM-DD HH:MM:SS ±HHMM');
+  }
+
+  const [, datePart, timePart, timezonePart] = match;
+
+  // Insert 'T' between date and time
+  // Format timezone offset by inserting a colon (e.g., -0800 -> -08:00)
+  const formattedTimezone = `${timezonePart.slice(0, 3)}:${timezonePart.slice(3)}`;
+
+  return `${datePart}T${timePart}${formattedTimezone}`;
+}


### PR DESCRIPTION
This pull request includes changes to the `cp-webapp` project, specifically focusing on date formatting improvements and utility functions. The main changes involve adding a new utility function for date conversion and updating the `CommitsList` component to use this function.

Date formatting improvements:

* [`cp-webapp/src/components/snapshot-view/commits-list.tsx`](diffhunk://#diff-b0aaaeb8c0749d9884e1b590096bc80b7ddfc4c89604e4804eac199cf33ec73eR25): Added `convertToISO8601` import and updated the date formatting logic in the `CommitsList` component to use the new `convertToISO8601` function. [[1]](diffhunk://#diff-b0aaaeb8c0749d9884e1b590096bc80b7ddfc4c89604e4804eac199cf33ec73eR25) [[2]](diffhunk://#diff-b0aaaeb8c0749d9884e1b590096bc80b7ddfc4c89604e4804eac199cf33ec73eL159-R160)

Utility functions:

* [`cp-webapp/src/lib/utils.ts`](diffhunk://#diff-7dc76415b3fe199037a91340bc71aac2b10afbccf593f5903616a300cb4c0fcdR24-R41): Added a new function `convertToISO8601` to convert date strings into ISO 8601 format.